### PR TITLE
Adjust maven publishing

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -170,6 +170,7 @@ jobs:
           GHA_MAVENCENTRAL_GPG_PUBLIC_KEY: ${{ secrets.SONATYPE_GPG_KEY_PUBLIC }}
           GHA_MAVENCENTRAL_GPG_SECRET_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
           GHA_MAVENCENTRAL_GPG_PASSPHRASE: ${{ secrets.SONATYPE_GPG_KEY_PASSWORD }}
+
         run: |
           mkdir -p $HOME/.jreleaser
           cat << EOF >>$HOME/.jreleaser/config.toml
@@ -187,6 +188,7 @@ jobs:
         shell: bash
         env:
           GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
+          GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
         run: |
             mvn -B versions:set -DnewVersion=$GHA_MAVENCENTRAL_VERSION
 
@@ -195,21 +197,25 @@ jobs:
         run: |
             # include publication profile in all commands so that modules which
             # are excluded from publishing (i.e. examples) can be disabled
-            mvn -B -Ppublication jreleaser:config
+            mvn -B -Ppublication jreleaser:config -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
 
       - name: JReleaser stage
+        env:
+          GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
+          GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
         id: stage
         shell: bash
         run: |
-          mvn -B -Ppublication deploy
+          mvn -B -Ppublication deploy -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
 
       - name: JReleaser release
         id: release
         shell: bash
         env:
           GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
+          GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
         run: |
-          mvn -B -Ppublication jreleaser:full-release
+          mvn -B -Ppublication jreleaser:full-release -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
           
           echo ":tada: Published $GHA_MAVENCENTRAL_VERSION to Maven Central." >> $GITHUB_STEP_SUMMARY
           echo "version=$GHA_MAVENCENTRAL_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -183,23 +183,31 @@ jobs:
           JRELEASER_GPG_SECRET_KEY="""$(echo "$GHA_MAVENCENTRAL_GPG_SECRET_KEY" | base64 --decode)"""
           EOF
 
-      - name: Verify JReleaser Config
+      - name: Set version
         shell: bash
         env:
           GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
         run: |
-            mvn -B versions:set -DnewVersion=$GHA_MAVENCENTRAL_VERSION jreleaser:config
-            mvn clean
+            mvn -B versions:set -DnewVersion=$GHA_MAVENCENTRAL_VERSION
+      - name: Verify JReleaser Config
+        shell: bash
+        run: |
+            # include publication profile here so that modules which
+            # are excluded from publishing (i.e. examples) can be disabled
+            mvn -B -Ppublication jreleaser:config
 
-      - name: JReleaser Publish (${{ steps.final-version.outputs.version }})
+      - name: JReleaser stage
+        id: publish
+        shell: bash
+        run: |
+          mvn -B -Ppublication deploy
+      - name: JReleaser release
         id: publish
         shell: bash
         env:
           GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
         run: |
-          mvn -B versions:set -DnewVersion=$GHA_MAVENCENTRAL_VERSION
-          mvn -B -Ppublication deploy
-          mvn -B jreleaser:full-release
+          mvn -B -Ppublication jreleaser:full-release
           
           echo ":tada: Published $GHA_MAVENCENTRAL_VERSION to Maven Central." >> $GITHUB_STEP_SUMMARY
           echo "version=$GHA_MAVENCENTRAL_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -206,7 +206,7 @@ jobs:
         id: stage
         shell: bash
         run: |
-          mvn --non-recursive -B -Ppublication deploy -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
+          mvn -B -Ppublication deploy -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
 
       - name: JReleaser release
         id: release

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -215,7 +215,7 @@ jobs:
           GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
           GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
         run: |
-          mvn -B -Ppublication jreleaser:full-release -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
+          mvn --non-recursive -B -Ppublication jreleaser:full-release -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
           
           echo ":tada: Published $GHA_MAVENCENTRAL_VERSION to Maven Central." >> $GITHUB_STEP_SUMMARY
           echo "version=$GHA_MAVENCENTRAL_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -189,10 +189,11 @@ jobs:
           GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
         run: |
             mvn -B versions:set -DnewVersion=$GHA_MAVENCENTRAL_VERSION
+
       - name: Verify JReleaser Config
         shell: bash
         run: |
-            # include publication profile here so that modules which
+            # include publication profile in all commands so that modules which
             # are excluded from publishing (i.e. examples) can be disabled
             mvn -B -Ppublication jreleaser:config
 
@@ -201,6 +202,7 @@ jobs:
         shell: bash
         run: |
           mvn -B -Ppublication deploy
+
       - name: JReleaser release
         id: release
         shell: bash
@@ -226,6 +228,6 @@ jobs:
         with:
           name: reports
           path: |
-            **/out
-            **/build/reports/
-            **/build/test-results/
+            **/target/site
+            **/target/reports/
+            **/target/surefire-reports

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -197,12 +197,12 @@ jobs:
             mvn -B -Ppublication jreleaser:config
 
       - name: JReleaser stage
-        id: publish
+        id: stage
         shell: bash
         run: |
           mvn -B -Ppublication deploy
       - name: JReleaser release
-        id: publish
+        id: release
         shell: bash
         env:
           GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -197,7 +197,7 @@ jobs:
         run: |
             # include publication profile in all commands so that modules which
             # are excluded from publishing (i.e. examples) can be disabled
-            mvn -B -Ppublication jreleaser:config -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
+            mvn --non-recursive -B -Ppublication jreleaser:config -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
 
       - name: JReleaser stage
         env:
@@ -206,7 +206,7 @@ jobs:
         id: stage
         shell: bash
         run: |
-          mvn -B -Ppublication deploy -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
+          mvn --non-recursive -B -Ppublication deploy -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
 
       - name: JReleaser release
         id: release

--- a/README-maven-publish.md
+++ b/README-maven-publish.md
@@ -105,6 +105,7 @@ Afterwards, you must also configure JReleaser in your pom.xml file:
             <plugin>
                 <groupId>org.jreleaser</groupId>
                 <artifactId>jreleaser-maven-plugin</artifactId>
+                <inherited>false</inherited>
                 <configuration>
                     <jreleaser>
                         <signing>

--- a/README-maven-publish.md
+++ b/README-maven-publish.md
@@ -117,7 +117,7 @@ Afterwards, you must also configure JReleaser in your pom.xml file:
                                     <sonatype>
                                         <active>RELEASE</active>
                                         <url>https://central.sonatype.com/api/v1/publisher</url>
-                                        <stagingRepositories>build/staging-deploy</stagingRepositories>
+                                        <stagingRepositories>target/staging-deploy</stagingRepositories>
                                     </sonatype>
                                 </mavenCentral>
                                 <nexus2>
@@ -129,7 +129,7 @@ Afterwards, you must also configure JReleaser in your pom.xml file:
                                         <snapshotSupported>true</snapshotSupported>
                                         <closeRepository>true</closeRepository>
                                         <releaseRepository>true</releaseRepository>
-                                        <stagingRepositories>build/staging-deploy</stagingRepositories>
+                                        <stagingRepositories>target/staging-deploy</stagingRepositories>
                                     </maven-central>
                                 </nexus2>
                             </maven>


### PR DESCRIPTION
 - split into set-version, stage and release steps
 - change `build` to `target` in maven example docs
 - adjust report upload paths
 - explicitly set the tag via command-line parameter
 - multi-module projects
   - add profile parameter to all steps so that example modules can be disabled
   - add `inherit` tag in maven example docs (does not affect single module projects)
   - add  `--non-recursive` whenever jreleaser is called

Example: https://github.com/entur/jwt-resource-server/actions/runs/15781358779/job/44487544706 -> https://repo1.maven.org/maven2/org/entur/jwt-rs/
