### PR TITLE
fix: Fixed file push behavior and get-version requirement behavior

### DIFF
--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -58,43 +58,13 @@ runs:
         GHA_MAVENCENTRAL_VERSION_FILE_NAME: ${{ inputs.version_file_name }}
         GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME: ${{ inputs.version_file_variable_name }}
       run: |
-        # Credit where credit is due
-        # https://unix.stackexchange.com/a/83481
-        function xmlpath()
-        {
-            local expr="${1//\// }"
-            local path=()
-            local chunk tag data
-            local line=1
-
-            while IFS='' read -r -d '<' chunk; do
-                IFS='>' read -r tag data <<< "$chunk"
-                
-                tag=(${tag[0]})
-                case "$tag" in
-                '?'*) ;;
-                '!--'*) ;;
-                '![CDATA['*) data="${tag:8:${#tag}-10}" ;;
-                ?*'/') ;;
-                '/'?*) line=$(($line - 1)) unset path[${#path[@]}-1] ;;
-                ?*) line=$(($line + 1)) path+=("$tag") ;;
-                esac
-
-                if [[ "${path[@]}" == "$expr" ]]; then
-                    echo "$line $data"
-                    break
-                fi
-            done
-        }
-
         file_ext=$(echo "$GHA_MAVENCENTRAL_VERSION_FILE_NAME" | awk -F. '{print tolower($NF)}')
         if [ "$file_ext" = "properties" ]; then
           previous_version=$(cat $GHA_MAVENCENTRAL_VERSION_FILE_NAME | grep -w "$GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME" | cut -d'=' -f2)
         elif [ $file_ext = "xml" ]; then
-          if test -f $GHA_MAVENCENTRAL_VERSION_FILE_NAME; then
-            output=$(xmlpath "project/$GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME" < $GHA_MAVENCENTRAL_VERSION_FILE_NAME)
-            previous_version=${output#* }
-
+          previous_version=$(mvn help:evaluate -f $GHA_MAVENCENTRAL_VERSION_FILE_NAME -Dexpression="project.$GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME" -q -DforceStdout)
+          if [ $previous_version = "null object or invalid expression" ]; then
+            previous_version=""
           fi
         else
           echo "Expected a version file to be a gradle .properties or pom .xml file for version extraction"

--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -8,7 +8,7 @@ inputs:
   # FILE STRATEGY
   version_file_name:
     description: "The name of the file containing the version number to get"
-    required: true
+    required: false
   version_file_variable_name:
     description: "The name of the file variable containing the version number to get"
     required: false

--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -32,48 +32,11 @@
           GHA_MAVENCENTRAL_VERSION_FILE_NAME: ${{ inputs.version_file_name }}
           GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME: ${{ inputs.version_file_variable_name }}
         run: |
-          # Credit where credit is due
-          # https://unix.stackexchange.com/a/83481
-          function xmlpath()
-          {
-              local expr="${1//\// }"
-              local path=()
-              local chunk tag data
-              local line=1
-
-              while IFS='' read -r -d '<' chunk; do
-                  IFS='>' read -r tag data <<< "$chunk"
-                  
-                  tag=(${tag[0]})
-                  case "$tag" in
-                  '?'*) ;;
-                  '!--'*) ;;
-                  '![CDATA['*) data="${tag:8:${#tag}-10}" ;;
-                  ?*'/') ;;
-                  '/'?*) line=$(($line - 1)) unset path[${#path[@]}-1] ;;
-                  ?*) line=$(($line + 1)) path+=("$tag") ;;
-                  esac
-
-                  if [[ "${path[@]}" == "$expr" ]]; then
-                      echo "$line $data"
-                      break
-                  fi
-              done
-          }
-
           file_ext=$(echo "$GHA_MAVENCENTRAL_VERSION_FILE_NAME" | awk -F. '{print tolower($NF)}')
           if [ "$file_ext" = "properties" ]; then
             sed -i "s/${GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME}=.*/${GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME}=$GHA_MAVENCENTRAL_VERSION/" ${GHA_MAVENCENTRAL_VERSION_FILE_NAME}
           elif [ "$file_ext" = "xml" ]; then
-            if test -f $GHA_MAVENCENTRAL_VERSION_FILE_NAME; then
-              output=$(xmlpath "project/$GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME" < $GHA_MAVENCENTRAL_VERSION_FILE_NAME)
-              previous_version=${output#* }
-              previous_version_line=${output%"$previous_version"}
-              tmp_file_name="$GHA_MAVENCENTRAL_VERSION_FILE_NAME.tmp"
-
-              # This should probably be made a bit more safe
-              awk -v old="$previous_version" -v new="$GHA_MAVENCENTRAL_VERSION" -v n="$previous_version_line" 'NR==n {sub(old,new)}1' "$GHA_MAVENCENTRAL_VERSION_FILE_NAME" > $tmp_file_name && mv $tmp_file_name "$GHA_MAVENCENTRAL_VERSION_FILE_NAME"
-            fi
+            mvn versions:set -f $GHA_MAVENCENTRAL_VERSION_FILE_NAME -DnewVersion=$GHA_MAVENCENTRAL_VERSION -DgenerateBackupPoms=false -DprocessAllModules=true
           else
             echo "Expected a version file to be a gradle .properties or pom .xml file for version replacement"
             exit 1
@@ -89,11 +52,9 @@
         env:
             GHA_MAVENCENTRAL_GITHUB_REF_NAME: ${{ github.ref }}
             GHA_MAVENCENTRAL_VERSION: ${{ steps.results.outputs.version }}
-            GHA_MAVENCENTRAL_VERSION_FILE_NAME: ${{ inputs.version_file_name }}
-            GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME: ${{ inputs.version_file_variable_name }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add "${GHA_MAVENCENTRAL_VERSION_FILE_NAME}"
-          git commit -m "chore(bump): ${GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME} to ${GHA_MAVENCENTRAL_VERSION} [skip ci]"
-          git push origin "${GHA_MAVENCENTRAL_GITHUB_REF_NAME}" --force
+          git add "**/pom.xml" "**/gradle.properties"
+          git commit -m "chore(bump): Bump version to ${GHA_MAVENCENTRAL_VERSION} [skip ci]"
+          git push origin "${GHA_MAVENCENTRAL_GITHUB_REF_NAME}"

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -215,6 +215,14 @@ jobs:
         run: |
           ./gradlew -Pversion=$GHA_MAVENCENTRAL_VERSION -P$GHA_MAVENCENTRAL_VERSION_FILE_VARIABLE_NAME=$GHA_MAVENCENTRAL_VERSION publish --info --stacktrace
 
+      - name: Prepare and Push Current Release Version (${{ steps.final-version.outputs.version }})
+        uses: entur/gha-maven-central/.github/actions/update-version@v1
+        if: ${{ inputs.snapshot == false && inputs.version_strategy == 'file' }}
+        with:
+          version: ${{ steps.final-version.outputs.version }}
+          version_file_name: ${{ inputs.version_file_name }}
+          push_to_repo: ${{ inputs.push_to_repo }}
+
       - name: JReleaser release
         id: release
         shell: bash
@@ -228,7 +236,7 @@ jobs:
           echo ":tada: Deployed $GHA_MAVENCENTRAL_VERSION to Maven Central." >> $GITHUB_STEP_SUMMARY
           echo "version=$GHA_MAVENCENTRAL_VERSION" >> $GITHUB_OUTPUT
         
-      - name: Prepare Next Version (${{ steps.final-version.outputs.next_version }})
+      - name: Prepare and Push Next Version (${{ steps.final-version.outputs.next_version }})
         uses: entur/gha-maven-central/.github/actions/update-version@v1
         if: ${{ inputs.snapshot == false && inputs.version_strategy == 'file' }}
         with:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -197,12 +197,13 @@ jobs:
       - name: Set version
         shell: bash
         env:
+          GHA_MAVENCENTRAL_VERSION_FILE_NAME: ${{ inputs.version_file_name}}
           GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
           GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
           JFROG_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
           JFROG_PASS: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
         run: |
-          mvn -B versions:set -DnewVersion=$GHA_MAVENCENTRAL_VERSION -DgenerateBackupPoms=false -DprocessAllModules=true
+          mvn -B versions:set -f $GHA_MAVENCENTRAL_VERSION_FILE_NAME -DnewVersion=$GHA_MAVENCENTRAL_VERSION -DgenerateBackupPoms=false -DprocessAllModules=true
 
       - name: Verify JReleaser Config
         shell: bash

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -202,7 +202,7 @@ jobs:
           JFROG_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
           JFROG_PASS: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
         run: |
-            mvn -B versions:set -DnewVersion=$GHA_MAVENCENTRAL_VERSION
+          mvn -B versions:set -DnewVersion=$GHA_MAVENCENTRAL_VERSION -DgenerateBackupPoms=false -DprocessAllModules=true
 
       - name: Verify JReleaser Config
         shell: bash
@@ -210,9 +210,9 @@ jobs:
           JFROG_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
           JFROG_PASS: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
         run: |
-            # include publication profile in all commands so that modules which
-            # are excluded from publishing (i.e. examples) can be disabled
-            mvn --non-recursive -B -Ppublication jreleaser:config -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
+          # include publication profile in all commands so that modules which
+          # are excluded from publishing (i.e. examples) can be disabled
+          mvn --non-recursive -B -Ppublication jreleaser:config -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
 
       - name: JReleaser stage
         env:
@@ -224,6 +224,14 @@ jobs:
         shell: bash
         run: |
           mvn -B -Ppublication deploy -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
+
+      - name: Prepare and Push Current Release Version (${{ steps.final-version.outputs.version }})
+        uses: entur/gha-maven-central/.github/actions/update-version@v1
+        if: ${{ inputs.snapshot == false && inputs.version_strategy == 'file' }}
+        with:
+          version: ${{ steps.final-version.outputs.version }}
+          version_file_name: ${{ inputs.version_file_name }}
+          push_to_repo: ${{ inputs.push_to_repo }}
 
       - name: JReleaser release
         id: release
@@ -239,7 +247,7 @@ jobs:
           echo ":tada: Published $GHA_MAVENCENTRAL_VERSION to Maven Central." >> $GITHUB_STEP_SUMMARY
           echo "version=$GHA_MAVENCENTRAL_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Prepare Next Version (${{ steps.final-version.outputs.next_version }})
+      - name: Prepare and Push Next Version (${{ steps.final-version.outputs.next_version }})
         uses: entur/gha-maven-central/.github/actions/update-version@v1
         if: ${{ inputs.snapshot == false && inputs.version_strategy == 'file' }}
         with:


### PR DESCRIPTION
Fixed:
* The release version will now be pushed back to the default branch before generating a release tag
* The get-version action will now no longer require a file_name if the strategy used is 'tag'
* Indentation
* Force push flag being set, causing some github rulesets to generate errors on push

Improved:
* Maven version get version behavior