### PR TITLE
Refactor: Extract JReleaser Logic into Reusable Composite Action

### DIFF
--- a/.github/actions/jreleaser-release/action.yml
+++ b/.github/actions/jreleaser-release/action.yml
@@ -1,0 +1,101 @@
+name: JReleaser Maven Central Release
+description: Handles JReleaser configuration, staging, and release to Maven Central
+inputs:
+  version:
+    description: "The version to release"
+    required: true
+  version_tag_prefix:
+    description: "The prefix for the git tag"
+    required: false
+    default: "v"
+  github_token:
+    description: "GitHub token for JReleaser"
+    required: true
+  sonatype_username:
+    description: "Sonatype username"
+    required: true
+  sonatype_password:
+    description: "Sonatype password/token"
+    required: true
+  gpg_public_key:
+    description: "Base64-encoded GPG public key"
+    required: true
+  gpg_secret_key:
+    description: "Base64-encoded GPG secret key"
+    required: true
+  gpg_passphrase:
+    description: "GPG key passphrase"
+    required: true
+  artifactory_user:
+    description: "JFrog Artifactory user (optional)"
+    required: false
+    default: ""
+  artifactory_token:
+    description: "JFrog Artifactory token (optional)"
+    required: false
+    default: ""
+
+outputs:
+  version:
+    description: "The version that was released"
+    value: ${{ steps.release.outputs.version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate JReleaser Maven Central Config
+      shell: bash
+      env:
+        GHA_MAVENCENTRAL_GITHUB_TOKEN: ${{ inputs.github_token }}
+        GHA_MAVENCENTRAL_SONATYPE_USERNAME: ${{ inputs.sonatype_username }}
+        GHA_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ inputs.sonatype_password }}
+        GHA_MAVENCENTRAL_GPG_PUBLIC_KEY: ${{ inputs.gpg_public_key }}
+        GHA_MAVENCENTRAL_GPG_SECRET_KEY: ${{ inputs.gpg_secret_key }}
+        GHA_MAVENCENTRAL_GPG_PASSPHRASE: ${{ inputs.gpg_passphrase }}
+      run: |
+        mkdir -p $HOME/.jreleaser
+        cat << EOF >>$HOME/.jreleaser/config.toml
+        JRELEASER_GITHUB_TOKEN="$GHA_MAVENCENTRAL_GITHUB_TOKEN"
+        JRELEASER_NEXUS2_USERNAME="$GHA_MAVENCENTRAL_SONATYPE_USERNAME"
+        JRELEASER_NEXUS2_PASSWORD="$GHA_MAVENCENTRAL_SONATYPE_PASSWORD"
+        JRELEASER_MAVENCENTRAL_USERNAME="$GHA_MAVENCENTRAL_SONATYPE_USERNAME"
+        JRELEASER_MAVENCENTRAL_PASSWORD="$GHA_MAVENCENTRAL_SONATYPE_PASSWORD"
+        JRELEASER_GPG_PASSPHRASE="$GHA_MAVENCENTRAL_GPG_PASSPHRASE"
+        JRELEASER_GPG_PUBLIC_KEY="""$(echo "$GHA_MAVENCENTRAL_GPG_PUBLIC_KEY" | base64 --decode)"""
+        JRELEASER_GPG_SECRET_KEY="""$(echo "$GHA_MAVENCENTRAL_GPG_SECRET_KEY" | base64 --decode)"""
+        EOF
+
+    - name: Verify JReleaser Config
+      shell: bash
+      env:
+        GHA_MAVENCENTRAL_VERSION: ${{ inputs.version }}
+        GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
+        JFROG_USER: ${{ inputs.artifactory_user }}
+        JFROG_PASS: ${{ inputs.artifactory_token }}
+      run: |
+        mvn --non-recursive -B -Ppublication jreleaser:config -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
+
+    - name: JReleaser stage
+      id: stage
+      shell: bash
+      env:
+        GHA_MAVENCENTRAL_VERSION: ${{ inputs.version }}
+        GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
+        JFROG_USER: ${{ inputs.artifactory_user }}
+        JFROG_PASS: ${{ inputs.artifactory_token }}
+      run: |
+        mvn -B -Ppublication deploy -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
+
+    - name: JReleaser release
+      id: release
+      shell: bash
+      env:
+        GHA_MAVENCENTRAL_VERSION: ${{ inputs.version }}
+        GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
+        JFROG_USER: ${{ inputs.artifactory_user }}
+        JFROG_PASS: ${{ inputs.artifactory_token }}
+      run: |
+        mvn --non-recursive -B -Ppublication jreleaser:full-release -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
+
+        echo ":tada: Published $GHA_MAVENCENTRAL_VERSION to Maven Central." >> $GITHUB_STEP_SUMMARY
+        echo "version=$GHA_MAVENCENTRAL_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -100,7 +100,7 @@ jobs:
       JRELEASER_UPDATE: true
       JRELEASER_GIT_ROOT_SEARCH: true
     outputs:
-      version: ${{ steps.publish.outputs.version }}
+      version: ${{ steps.release.outputs.version || steps.final-version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -181,29 +181,6 @@ jobs:
           echo "NEXT_VERSION=$major.$minor.$((patch+1))-SNAPSHOT" >> $GITHUB_ENV
           echo "next_version=$major.$minor.$((patch+1))-SNAPSHOT" >> $GITHUB_OUTPUT
 
-      - name: Generate JReleaser Maven Central Config
-        shell: bash
-        env:
-          GHA_MAVENCENTRAL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GHA_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_AUTH_USER }}
-          GHA_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_AUTH_TOKEN }}
-          GHA_MAVENCENTRAL_GPG_PUBLIC_KEY: ${{ secrets.SONATYPE_GPG_KEY_PUBLIC }}
-          GHA_MAVENCENTRAL_GPG_SECRET_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
-          GHA_MAVENCENTRAL_GPG_PASSPHRASE: ${{ secrets.SONATYPE_GPG_KEY_PASSWORD }}
-
-        run: |
-          mkdir -p $HOME/.jreleaser
-          cat << EOF >>$HOME/.jreleaser/config.toml
-          JRELEASER_GITHUB_TOKEN="$GHA_MAVENCENTRAL_GITHUB_TOKEN"
-          JRELEASER_NEXUS2_USERNAME="$GHA_MAVENCENTRAL_SONATYPE_USERNAME"
-          JRELEASER_NEXUS2_PASSWORD="$GHA_MAVENCENTRAL_SONATYPE_PASSWORD"
-          JRELEASER_MAVENCENTRAL_USERNAME="$GHA_MAVENCENTRAL_SONATYPE_USERNAME"
-          JRELEASER_MAVENCENTRAL_PASSWORD="$GHA_MAVENCENTRAL_SONATYPE_PASSWORD"
-          JRELEASER_GPG_PASSPHRASE="$GHA_MAVENCENTRAL_GPG_PASSPHRASE"
-          JRELEASER_GPG_PUBLIC_KEY="""$(echo "$GHA_MAVENCENTRAL_GPG_PUBLIC_KEY" | base64 --decode)"""
-          JRELEASER_GPG_SECRET_KEY="""$(echo "$GHA_MAVENCENTRAL_GPG_SECRET_KEY" | base64 --decode)"""
-          EOF
-
       - name: Set version
         shell: bash
         env:
@@ -215,27 +192,6 @@ jobs:
         run: |
           mvn -B versions:set -f $GHA_MAVENCENTRAL_VERSION_FILE_NAME -DnewVersion=$GHA_MAVENCENTRAL_VERSION -DgenerateBackupPoms=false -DprocessAllModules=true
 
-      - name: Verify JReleaser Config
-        shell: bash
-        env:
-          JFROG_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
-          JFROG_PASS: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
-        run: |
-          # include publication profile in all commands so that modules which
-          # are excluded from publishing (i.e. examples) can be disabled
-          mvn --non-recursive -B -Ppublication jreleaser:config -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
-
-      - name: JReleaser stage
-        env:
-          GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
-          GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
-          JFROG_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
-          JFROG_PASS: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
-        id: stage
-        shell: bash
-        run: |
-          mvn -B -Ppublication deploy -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
-
       - name: Prepare and Push Current Release Version (${{ steps.final-version.outputs.version }})
         id: push-current
         uses: entur/gha-maven-central/.github/actions/update-version@v1
@@ -245,19 +201,20 @@ jobs:
           version_file_name: ${{ inputs.version_file_name }}
           push_to_repo: ${{ inputs.push_to_repo }}
 
-      - name: JReleaser release
+      - name: JReleaser Release to Maven Central
         id: release
-        shell: bash
-        env:
-          GHA_MAVENCENTRAL_VERSION: ${{ steps.final-version.outputs.version }}
-          GHA_TAG_PREFIX: ${{ inputs.version_tag_prefix }}
-          JFROG_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
-          JFROG_PASS: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
-        run: |
-          mvn --non-recursive -B -Ppublication jreleaser:full-release -Djreleaser.tag.name=${GHA_TAG_PREFIX}${GHA_MAVENCENTRAL_VERSION}
-          
-          echo ":tada: Published $GHA_MAVENCENTRAL_VERSION to Maven Central." >> $GITHUB_STEP_SUMMARY
-          echo "version=$GHA_MAVENCENTRAL_VERSION" >> $GITHUB_OUTPUT
+        uses: entur/gha-maven-central/.github/actions/jreleaser-release@v1
+        with:
+          version: ${{ steps.final-version.outputs.version }}
+          version_tag_prefix: ${{ inputs.version_tag_prefix }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          sonatype_username: ${{ secrets.SONATYPE_AUTH_USER }}
+          sonatype_password: ${{ secrets.SONATYPE_AUTH_TOKEN }}
+          gpg_public_key: ${{ secrets.SONATYPE_GPG_KEY_PUBLIC }}
+          gpg_secret_key: ${{ secrets.SONATYPE_GPG_KEY }}
+          gpg_passphrase: ${{ secrets.SONATYPE_GPG_KEY_PASSWORD }}
+          artifactory_user: ${{ secrets.ARTIFACTORY_AUTH_USER }}
+          artifactory_token: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
 
       - name: Prepare and Push Next Version (${{ steps.final-version.outputs.next_version }})
         uses: entur/gha-maven-central/.github/actions/update-version@v1

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,168 @@
+name: Release to Maven Central (Maven)
+description: "Publish artifacts to Maven Central with custom version. Use this when you manage versioning yourself."
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: "Job Runner"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      git_ref:
+        description: "Option to override git reference to checkout before build"
+        type: string
+        required: false
+      settings-xml_file:
+        description: "Link to the external settings.xml file"
+        required: false
+        type: string
+        default: ""
+      java_version:
+        description: "Java Runtime Version"
+        required: false
+        type: number
+        default: 21
+      java_distribution:
+        description: "Java distribution for Setup-Java"
+        required: false
+        type: string
+        default: "liberica"
+      version:
+        description: "The version to release (e.g., '1.3.0' or '1.3.0-SNAPSHOT'). This is required for this standalone workflow."
+        required: true
+        type: string
+      version_file_name:
+        description: "The name of the file containing the version number"
+        required: false
+        type: string
+        default: "pom.xml"
+      version_tag_prefix:
+        description: "The prefix for the git tag (e.g., 'v' for 'v1.0.0')"
+        required: false
+        type: string
+        default: "v"
+      snapshot:
+        description: "Whether the artifact is a snapshot or not"
+        required: false
+        type: boolean
+        default: false
+      skip_version_update:
+        description: "Skip setting version in pom.xml (useful if version is already set)"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      GIT_SSH_KEY:
+        description: "Option to override git ssh key to checkout before build"
+        required: false
+      SONATYPE_AUTH_USER:
+        required: true
+      SONATYPE_AUTH_TOKEN:
+        required: true
+      SONATYPE_GPG_KEY_PUBLIC:
+        required: true
+      SONATYPE_GPG_KEY:
+        required: true
+      SONATYPE_GPG_KEY_PASSWORD:
+        required: true
+
+    outputs:
+      version:
+        description: Published version
+        value: ${{ jobs.release.outputs.version }}
+
+concurrency:
+  group: maven-release-${{ github.ref }}
+
+jobs:
+  release:
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: write
+      issues: write
+      packages: write
+    env:
+      JRELEASER_MAVENCENTRAL_URL: "https://central.sonatype.com/api/v1/publisher"
+      JRELEASER_DEPLOY_MAVEN_MAVENCENTRAL_ACTIVE: "RELEASE"
+      JRELEASER_DEPLOY_MAVEN_NEXUS2_ACTIVE: "SNAPSHOT"
+      JRELEASER_NEXUS2_URL: "https://ossrh-staging-api.central.sonatype.com/service/local"
+      JRELEASER_NEXUS2_SNAPSHOT_URL: "https://central.sonatype.com/repository/maven-snapshots"
+      JRELEASER_OVERWRITE: true
+      JRELEASER_UPDATE: true
+      JRELEASER_GIT_ROOT_SEARCH: true
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        if: ${{ inputs.git_ref == '' }}
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.GIT_SSH_KEY }}
+
+      - name: Checkout code with reference
+        uses: actions/checkout@v4
+        if: ${{ inputs.git_ref != '' }}
+        with:
+          ref: ${{ inputs.git_ref }}
+          fetch-depth: 0
+          ssh-key: ${{ secrets.GIT_SSH_KEY }}
+
+      - name: Set up Java ${{ inputs.java_version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: ${{ inputs.java_distribution }}
+          cache: maven
+
+      - name: Copy maven settings
+        if: ${{ inputs.settings-xml_file != '' }}
+        run: |
+          wget ${{ inputs.settings-xml_file }} -O ~/.m2/settings.xml
+
+      - name: Validate version input
+        shell: bash
+        env:
+          GHA_MAVENCENTRAL_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -z "$GHA_MAVENCENTRAL_VERSION" ]; then
+            echo "Error: version input is required for this workflow"
+            exit 1
+          fi
+          echo "Using version: $GHA_MAVENCENTRAL_VERSION"
+
+      - name: Set version
+        if: ${{ inputs.skip_version_update == false }}
+        shell: bash
+        env:
+          GHA_MAVENCENTRAL_VERSION_FILE_NAME: ${{ inputs.version_file_name}}
+          GHA_MAVENCENTRAL_VERSION: ${{ inputs.version }}
+          JFROG_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
+          JFROG_PASS: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
+        run: |
+          mvn -B versions:set -f $GHA_MAVENCENTRAL_VERSION_FILE_NAME -DnewVersion=$GHA_MAVENCENTRAL_VERSION -DgenerateBackupPoms=false -DprocessAllModules=true
+
+      - name: JReleaser Release to Maven Central
+        id: release
+        uses: entur/gha-maven-central/.github/actions/jreleaser-release@v1
+        with:
+          version: ${{ inputs.version }}
+          version_tag_prefix: ${{ inputs.version_tag_prefix }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          sonatype_username: ${{ secrets.SONATYPE_AUTH_USER }}
+          sonatype_password: ${{ secrets.SONATYPE_AUTH_TOKEN }}
+          gpg_public_key: ${{ secrets.SONATYPE_GPG_KEY_PUBLIC }}
+          gpg_secret_key: ${{ secrets.SONATYPE_GPG_KEY }}
+          gpg_passphrase: ${{ secrets.SONATYPE_GPG_KEY_PASSWORD }}
+          artifactory_user: ${{ secrets.ARTIFACTORY_AUTH_USER }}
+          artifactory_token: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
+
+      - name: Upload Build Reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-reports
+          path: |
+            **/target/site
+            **/target/reports/
+            **/target/surefire-reports

--- a/README-maven-publish.md
+++ b/README-maven-publish.md
@@ -29,6 +29,10 @@ jobs:
 
 for snapshots.
 
+**Note:** If you want to manage versioning yourself and only use publishing functionality, see the [maven-release documentation](README-maven-release.md) for a standalone publishing workflow.
+
+## JReleaser Configuration
+
 Afterwards, you must also configure JReleaser in your pom.xml file:
 
 ```xml

--- a/README-maven-release.md
+++ b/README-maven-release.md
@@ -1,0 +1,132 @@
+# `gha-maven-central/maven-release`
+
+## Overview
+
+This is a standalone workflow for publishing Maven artifacts to Maven Central with custom versions. Use this workflow when you want to manage versioning yourself and only need the publishing functionality.
+
+## When to Use This Workflow
+
+Use `maven-release.yml` when:
+- You manage your own versioning strategy
+- You want to publish a specific version without automatic version incrementing
+- You need more control over the release process
+- You want to separate version management from the publishing step
+
+## Usage
+
+### Basic Usage
+
+```yml
+jobs:
+  publish-release:
+    name: Publish to Maven Central with JReleaser
+    uses: entur/gha-maven-central/.github/workflows/maven-release.yml@v1
+    with:
+      version: "1.3.0"  # Required: specify the version to publish
+    secrets: inherit
+```
+
+### Snapshot Release
+
+```yml
+jobs:
+  publish-snapshot:
+    name: Publish snapshot to Maven Central
+    uses: entur/gha-maven-central/.github/workflows/maven-release.yml@v1
+    with:
+      version: "1.3.0-SNAPSHOT"
+      snapshot: true
+    secrets: inherit
+```
+
+### Advanced Usage
+
+```yml
+jobs:
+  publish-custom:
+    name: Publish with custom configuration
+    uses: entur/gha-maven-central/.github/workflows/maven-release.yml@v1
+    with:
+      version: "1.3.0"
+      java_version: 17
+      java_distribution: "temurin"
+      skip_version_update: true  # Use this if version is already set in pom.xml
+    secrets: inherit
+```
+
+## Inputs
+
+| INPUT | TYPE | REQUIRED | DEFAULT | DESCRIPTION |
+|-------|------|----------|---------|-------------|
+| `runner` | string | false | `"ubuntu-24.04"` | Job Runner |
+| `git_ref` | string | false | | Option to override git reference to checkout before build |
+| `settings-xml_file` | string | false | | Link to the external settings.xml file |
+| `java_version` | number | false | `21` | Java Runtime Version |
+| `java_distribution` | string | false | `"liberica"` | Java distribution for Setup-Java |
+| `version` | string | **true** | | **Required**: The version to release (e.g., '1.3.0' or '1.3.0-SNAPSHOT') |
+| `version_file_name` | string | false | `"pom.xml"` | The name of the file containing the version number |
+| `version_tag_prefix` | string | false | `"v"` | The prefix for the git tag (e.g., 'v' for 'v1.0.0') |
+| `snapshot` | boolean | false | `false` | Whether the artifact is a snapshot or not |
+| `skip_version_update` | boolean | false | `false` | Skip setting version in pom.xml (useful if version is already set) |
+
+## Secrets
+
+The following secrets are required:
+
+| SECRET | REQUIRED | DESCRIPTION |
+|--------|----------|-------------|
+| `GIT_SSH_KEY` | false | Option to override git ssh key to checkout before build |
+| `SONATYPE_AUTH_USER` | **true** | Sonatype username for Maven Central |
+| `SONATYPE_AUTH_TOKEN` | **true** | Sonatype token for Maven Central |
+| `SONATYPE_GPG_KEY_PUBLIC` | **true** | Base64-encoded GPG public key |
+| `SONATYPE_GPG_KEY` | **true** | Base64-encoded GPG private key |
+| `SONATYPE_GPG_KEY_PASSWORD` | **true** | GPG key password |
+
+## Outputs
+
+| OUTPUT | DESCRIPTION |
+|--------|-------------|
+| `version` | Published version |
+
+## Complete Example Workflow
+
+Here's a complete example showing how to use this workflow in your repository:
+
+```yml
+name: Release to Maven Central
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version to release (e.g., 1.3.0)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    name: Release version ${{ inputs.release_version }}
+    uses: entur/gha-maven-central/.github/workflows/maven-release.yml@v1
+    with:
+      version: ${{ inputs.release_version }}
+    secrets: inherit
+```
+
+## Comparison with maven-publish.yml
+
+| Feature | maven-publish.yml | maven-release.yml |
+|---------|-------------------|----------------------------|
+| Automatic version detection | ✅ Yes | ❌ No (manual input) |
+| Automatic version increment | ✅ Yes | ❌ No |
+| Version push to repo | ✅ Yes | ❌ No |
+| JReleaser stage & release | ✅ Yes | ✅ Yes |
+| Control over version | ❌ Limited | ✅ Full control |
+| Use case | Automated releases | Manual/controlled releases |
+
+## Architecture
+
+Both workflows use a shared composite action (`.github/actions/jreleaser-release`) for JReleaser operations, ensuring consistency and eliminating code duplication.
+
+## JReleaser Configuration
+
+Ensure your `pom.xml` is configured with JReleaser as shown in the [main documentation](README-maven-publish.md#jreleaser-configuration).


### PR DESCRIPTION
### Summary
  This PR eliminates code duplication by extracting JReleaser operations into a shared composite action that both `maven-publish.yml` and `maven-release.yml`
  workflows can use.

  ### Why We Need Two Workflows

  **`maven-publish.yml`** - Automated Version Management + Publishing
  - Automatically detects and increments versions
  - Pushes version changes back to repository
  - Full end-to-end automation
  - **Use case**: Teams wanting fully automated releases

  **`maven-release.yml`** - Manual Version Control + Publishing
  - User provides the exact version to release
  - No automatic version detection/increment
  - No version commits to repository
  - **Use case**: Teams managing their own versioning strategy or requiring manual approval gates

  ### Key Differences

  | Feature | maven-publish.yml | maven-release.yml |
  |---------|-------------------|-------------------|
  | Version Management | ✅ Automatic | ❌ Manual (user provides) |
  | Version Detection | ✅ From file/tag | ❌ N/A |
  | Version Increment | ✅ Auto/Major/Minor/Patch | ❌ N/A |
  | Push to Repo | ✅ Yes | ❌ No |
  | JReleaser Publishing | ✅ Yes | ✅ Yes (shared action) |
  | Control Level | Limited | Full |

  **Example Scenarios:**
  - **maven-publish.yml**: "Automatically release v1.2.3 based on commit messages"
  - **maven-release.yml**: "I've already set version to 2.0.0, just publish it to Maven Central"

  ### Changes

  #### New Files
  - **`.github/actions/jreleaser-release/action.yml`**: New composite action that handles:
    - JReleaser Maven Central configuration
    - Config verification
    - Artifact staging (mvn deploy)
    - Release to Maven Central (jreleaser:full-release)

  #### Modified Workflows
  - **`maven-publish.yml`**: Replaced inline JReleaser steps with composite action
  - **`maven-release.yml`**: Replaced inline JReleaser steps with composite action

  #### Documentation
  - **`README-maven-publish.md`**: Updated to reflect changes
  - **`README-maven-release.md`**: Updated to reflect architecture and workflow differences

  ### Breaking Changes
  None. This is a pure refactoring with no user-facing changes.

